### PR TITLE
Fix critical bugs for portable installation

### DIFF
--- a/Sources/ProjectCoordinator/ProjectManager.swift
+++ b/Sources/ProjectCoordinator/ProjectManager.swift
@@ -21,7 +21,10 @@ actor ProjectManager {
     private let fileManager = FileManager.default
     
     init() {
-        self.knowledgeBasePath = "/Users/rogers/GitHub/Claude-Project-Coordinator/KnowledgeBase"
+        // Get the executable's directory and construct KnowledgeBase path relative to it
+        let executablePath = Bundle.main.executablePath ?? ""
+        let executableDir = URL(fileURLWithPath: executablePath).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().path
+        self.knowledgeBasePath = "\(executableDir)/KnowledgeBase"
     }
     
     func initialize() async {
@@ -186,10 +189,13 @@ actor ProjectManager {
         let projectsPath = "\(knowledgeBasePath)/projects"
         guard let files = try? fileManager.contentsOfDirectory(atPath: projectsPath) else { return }
         
-        for file in files where file.hasSuffix(".json") {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        
+        for file in files where file.hasSuffix(".json") && !file.contains("EXAMPLE") {
             let filePath = "\(projectsPath)/\(file)"
             if let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)),
-               let project = try? JSONDecoder().decode(Project.self, from: data) {
+               let project = try? decoder.decode(Project.self, from: data) {
                 projects[project.name] = project
             }
         }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,7 +20,7 @@ if [ -f ".build/release/project-coordinator" ]; then
     echo '{
   "project-coordinator": {
     "command": "<path-to-repo>/.build/release/project-coordinator",
-    "args": ["--port", "3000"]
+    "args": []
   }
 }'
     echo ""


### PR DESCRIPTION
- Replace hardcoded KnowledgeBase path with relative path
- Fix JSON date decoding to load existing projects
- Remove incorrect port arguments from build instructions
- Skip EXAMPLE.json.sample when loading projects

These changes ensure CPC works out-of-the-box regardless of installation location and properly loads existing project data.